### PR TITLE
Fix files unzipping in a directory too deep

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ repo](https://github.com/jedireza/gimp-hidpi/archive/master.zip).
 2.) Then unzip it into your local Gimp themes folder:
 
 ```bash
-$ unzip gimp-hidpi-master.zip -d ~/.gimp-2.8/themes/gimp-hidpi/
+$ unzip gimp-hidpi-master.zip -d ~/.gimp-2.8/themes/
 ```
 
 3.) Then choose the theme in Gimp via `Edit > Preferences`.


### PR DESCRIPTION
This fixes jedireza/gimp-hidpi#9, as suggested by @cwells.

Previously the files would unzip in ~/.gimp-2.8/themes/gimp-hidpi/gimp-hidpi-master/, since that is how the zip is structured. It now unzips in whatever name the zip creator chooses for the top directory.